### PR TITLE
Workaround bug which causes BackupPC fail to start when container launched with existing configuration

### DIFF
--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -35,7 +35,8 @@ if [ -f /firstrun ]; then
 	sed -ie "s/^\$Conf{CgiAdminUsers}\s*=\s*'\w*'/\$Conf{CgiAdminUsers} = '${BACKUPPC_WEB_USER:-backuppc}'/g" /etc/backuppc/config.pl
 	htpasswd -b -c /etc/backuppc/htpasswd ${BACKUPPC_WEB_USER:-backuppc} ${BACKUPPC_WEB_PASSWD:-password}
 	
-	# Workaround bug which causes BackupPC fail to start when container launched with existing configuration
+	# Workaround bug which causes BackupPC v3 fail to start when container launched with existing configuration.
+	# See https://github.com/adferrand/docker-backuppc/pull/18 for details.
 	sed -ie "s|^\$Conf{CgiURL}\s*=\s*''\(.*\)''|\$Conf{CgiURL} = '\1'|g" /etc/backuppc/config.pl
 
 	# Prepare lighttpd

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -36,7 +36,7 @@ if [ -f /firstrun ]; then
 	htpasswd -b -c /etc/backuppc/htpasswd ${BACKUPPC_WEB_USER:-backuppc} ${BACKUPPC_WEB_PASSWD:-password}
 	
 	# Workaround bug which causes BackupPC fail to start when container launched with existing configuration
-	sed -ie "s|^\$Conf{CgiURL}\s*=\s*''http://localhost/cgi-bin/BackupPC/BackupPC_Admin''|\$Conf{CgiURL} = 'http://localhost/cgi-bin/BackupPC/BackupPC_Admin'|g" /etc/backuppc/config.pl
+	sed -ie "s|^\$Conf{CgiURL}\s*=\s*''\(.*\)''|\$Conf{CgiURL} = '\1'|g" /etc/backuppc/config.pl
 
 	# Prepare lighttpd
 	if [ "$USE_SSL" = true ]; then

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -34,6 +34,9 @@ if [ -f /firstrun ]; then
 	# Configure WEB UI access
 	sed -ie "s/^\$Conf{CgiAdminUsers}\s*=\s*'\w*'/\$Conf{CgiAdminUsers} = '${BACKUPPC_WEB_USER:-backuppc}'/g" /etc/backuppc/config.pl
 	htpasswd -b -c /etc/backuppc/htpasswd ${BACKUPPC_WEB_USER:-backuppc} ${BACKUPPC_WEB_PASSWD:-password}
+	
+	# Workaround bug which causes BackupPC fail to start when container launched with existing configuration
+	sed -ie "s|^\$Conf{CgiURL}\s*=\s*''http://localhost/cgi-bin/BackupPC/BackupPC_Admin''|\$Conf{CgiURL} = 'http://localhost/cgi-bin/BackupPC/BackupPC_Admin'|g" /etc/backuppc/config.pl
 
 	# Prepare lighttpd
 	if [ "$USE_SSL" = true ]; then


### PR DESCRIPTION
This fixes issue with BackupPC 3.

How to reproduce issue:

1. Run container first time (/etc/backuppc is persistent storage) - it creates configuration and starts fine.
2. Stop and remove container.
3. Start container again (again with /etc/backuppc linked to persistent storage) - the backupPC fails to start now, complaining about bad configuration file.

The problem is that ./configure.pl script for some reason incorrectly modifies $Conf{CgiURL} parameter. It adds double quotes instead one quote symbol. Replacing from this:
```
$Conf{CgiURL} = 'http://localhost/cgi-bin/BackupPC/BackupPC_Admin';
```
to this:
```
$Conf{CgiURL} = ''http://localhost/cgi-bin/BackupPC/BackupPC_Admin'';
```

This pull request workarounds the issue.